### PR TITLE
Fixing ValueError thrown by int('')

### DIFF
--- a/web-scraping/youtube-extractor/extract_video_info.py
+++ b/web-scraping/youtube-extractor/extract_video_info.py
@@ -29,9 +29,11 @@ def get_video_info(url):
     result["tags"] = ', '.join([ meta.attrs.get("content") for meta in soup.find_all("meta", {"property": "og:video:tag"}) ])
     # number of likes
     text_yt_formatted_strings = soup.find_all("yt-formatted-string", {"id": "text", "class": "ytd-toggle-button-renderer"})
-    result["likes"] = int(''.join([ c for c in text_yt_formatted_strings[0].attrs.get("aria-label") if c.isdigit() ]))
+    result["likes"] = ''.join([ c for c in text_yt_formatted_strings[0].attrs.get("aria-label") if c.isdigit() ])
+    result["likes"] = 0 if result['likes'] == '' else int(result['likes'])
     # number of dislikes
-    result["dislikes"] = int(''.join([ c for c in text_yt_formatted_strings[1].attrs.get("aria-label") if c.isdigit() ]))
+    result["dislikes"] = ''.join([ c for c in text_yt_formatted_strings[1].attrs.get("aria-label") if c.isdigit() ])
+    result['dislikes'] = 0 if result['dislikes'] == '' else int(result['dislikes'])
 
     # channel details
     channel_tag = soup.find("yt-formatted-string", {"class": "ytd-channel-name"}).find("a")


### PR DESCRIPTION
YouTube can return `'No likes'` / `'No dislikes'`. The digits from this string give `''`. Casting `''` to an `int` gives `ValueError`.

Source: [Some YouTube videos](https://youtu.be/A3U3xpzBH2c) don't have likes or dislikes 😅 