### PR TITLE
Update arp operation code

### DIFF
--- a/scapy/arp-spoofer/arp_spoof.py
+++ b/scapy/arp-spoofer/arp_spoof.py
@@ -79,7 +79,7 @@ def restore(target_ip, host_ip, verbose=True):
     # get the real MAC address of spoofed (gateway, i.e router)
     host_mac = get_mac(host_ip)
     # crafting the restoring packet
-    arp_response = ARP(pdst=target_ip, hwdst=target_mac, psrc=host_ip, hwsrc=host_mac)
+    arp_response = ARP(pdst=target_ip, hwdst=target_mac, psrc=host_ip, hwsrc=host_mac, op="is-at")
     # sending the restoring packet
     # to restore the network to its normal process
     # we send each reply seven times for a good measure (count=7)


### PR DESCRIPTION
Just added the operation code for arp-reply. The packages that were been sent were arp requests. It worked, but didn't match the comments and variable name.