### PR TITLE
update: remove deprecated argument

### DIFF
--- a/machine-learning/hog-feature-extraction/hog.py
+++ b/machine-learning/hog-feature-extraction/hog.py
@@ -19,7 +19,7 @@ print(resized_img.shape)
 
 #creating hog features
 fd, hog_image = hog(resized_img, orientations=9, pixels_per_cell=(8, 8),
-                	cells_per_block=(2, 2), visualize=True, multichannel=True)
+                	cells_per_block=(2, 2), visualize=True, channel_axis=-1)
 print(fd.shape)
 print(hog_image.shape)
 plt.axis("off")


### PR DESCRIPTION
The`multichannel` argument is a deprecated, it will be removed in a future version 1.0, it's advised to use `channel_axis` instead.