### PR TITLE
Fix bug - textArea ranges extraction

### DIFF
--- a/gui-programming/rich-text-editor/rich_text_editor.py
+++ b/gui-programming/rich-text-editor/rich_text_editor.py
@@ -113,8 +113,10 @@ def fileManager(event=None, action=None):
 
             ranges = textArea.tag_ranges(tagName)
 
-            for i, tagRange in enumerate(ranges[::2]):
-                document['tags'][tagName].append([str(tagRange), str(ranges[i+1])])
+			assert (len(ranges)%2) == 0, "ranges should have a length multiple of 2"
+			for i in range(0, len(ranges), 2):
+				document['tags'][tagName].append([str(ranges[i]), str(ranges[i + 1])])
+
 
         if not filePath:
             # ask the user for a filename with the native file explorer.

--- a/gui-programming/rich-text-editor/rich_text_editor.py
+++ b/gui-programming/rich-text-editor/rich_text_editor.py
@@ -112,11 +112,9 @@ def fileManager(event=None, action=None):
             document['tags'][tagName] = []
 
             ranges = textArea.tag_ranges(tagName)
-
-			assert (len(ranges)%2) == 0, "ranges should have a length multiple of 2"
-			for i in range(0, len(ranges), 2):
-				document['tags'][tagName].append([str(ranges[i]), str(ranges[i + 1])])
-
+	
+            for i in range(0, len(ranges), 2):
+                document['tags'][tagName].append([str(ranges[i]), str(ranges[i + 1])])
 
         if not filePath:
             # ask the user for a filename with the native file explorer.


### PR DESCRIPTION
the previous implementation would output [[1,2],[3,3]] instead of [[1,2],[3,4]]
because i variable increase one by one instead of the expexted two by two